### PR TITLE
Fix issues blocking Scala.js' master from migrating to sbt-crossproject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,11 @@ before_script:
 script:
   - java -version
   - bin/scalafmt --test && sbt sbt-crossproject-test/scripted
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+before_cache:
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt -name "*.lock" -print -delete

--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -10,7 +10,7 @@ object Extra {
 
   val sbtPluginSettings = ScriptedPlugin.scriptedSettings ++ Seq(
       organization := "org.scala-native",
-      version := "0.1.0",
+      version := "0.2.0-SNAPSHOT",
       sbtPlugin := true,
       scalaVersion := "2.10.6",
       scriptedLaunchOpts += "-Dplugin.version=" + version.value,

--- a/sbt-crossproject-test/src/sbt-test/new-api/dependsOn/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/dependsOn/build.sbt
@@ -12,6 +12,14 @@ lazy val foo = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(scalaVersion := "2.11.8")
   .dependsOn(bar)
 
-lazy val fooJS = foo.js
-lazy val fooJVM = foo.jvm
+lazy val fooJS     = foo.js
+lazy val fooJVM    = foo.jvm
 lazy val fooNative = foo.native
+
+lazy val foobar = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .settings(scalaVersion := "2.11.8")
+  .dependsOn(bar % "test")
+
+lazy val foobarJS = foobar.js
+lazy val foobarJVM = foobar.jvm
+lazy val foobarNative = foobar.native

--- a/sbt-crossproject-test/src/sbt-test/plugins.sbt
+++ b/sbt-crossproject-test/src/sbt-test/plugins.sbt
@@ -1,5 +1,5 @@
 // COPIED FROM sbt-crossproject-test/src/sbt-test/plugins.sbt
-val pluginVersion = sys.props.get("plugin.version").getOrElse("0.1.0")
+val pluginVersion = sys.props.get("plugin.version").getOrElse("0.2.0-SNAPSHOT")
 
 addSbtPlugin("org.scala-js"     % "sbt-scalajs"              % "0.6.15")
 addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % pluginVersion)

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossPlugin.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossPlugin.scala
@@ -24,6 +24,14 @@ object CrossPlugin extends AutoPlugin {
       nonEmpty(groupID, "Group ID")
       new CrossGroupID(groupID)
     }
+
+    final implicit def toCrossClasspathDependencyConstructor(
+        cp: CrossProject): CrossClasspathDependency.Constructor =
+      new CrossClasspathDependency.Constructor(cp)
+
+    final implicit def toCrossClasspathDependency(
+        cp: CrossProject): CrossClasspathDependency =
+      new CrossClasspathDependency(cp, None)
   }
   import AutoImport._
 

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
@@ -82,9 +82,6 @@ final class CrossProject private[sbtcrossproject] (
   def overrideConfigs(cs: Configuration*): CrossProject =
     transform(_.overrideConfigs(cs: _*))
 
-  def settingSets(select: AddSettings*): CrossProject =
-    transform(_.settingSets(select: _*))
-
   def settings(ss: Def.SettingsDefinition*): CrossProject =
     transform(_.settings(ss: _*))
 

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
@@ -152,14 +152,6 @@ final class CrossProject private[sbtcrossproject] (
 }
 
 object CrossProject {
-  final implicit def crossClasspathDependencyConstructor(
-      cp: CrossProject): CrossClasspathDependency.Constructor =
-    new CrossClasspathDependency.Constructor(cp)
-
-  final implicit def crossClasspathDependency(
-      cp: CrossProject): CrossClasspathDependency =
-    new CrossClasspathDependency(cp, None)
-
   final class Builder(id: String, base: File, platforms: Platform*) {
     def crossType(crossType: CrossType): CrossProject =
       CrossProject(id, base, crossType, platforms: _*)

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProjectExtra.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProjectExtra.scala
@@ -26,8 +26,14 @@ object CrossProjectExtra {
         val jsPlatform =
           Select(
             Select(
-              Ident(newTermName("_root_")),
-              newTermName("scalajscrossproject")
+              Select(
+                Select(
+                  Ident(newTermName("_root_")),
+                  newTermName("org")
+                ),
+                newTermName("scalajs")
+              ),
+              newTermName("sbtplugin")
             ),
             newTermName("JSPlatform")
           )

--- a/sbt-scalajs-crossproject/src/main/scala/org/scalajs/sbtplugin/JSPlatform.scala
+++ b/sbt-scalajs-crossproject/src/main/scala/org/scalajs/sbtplugin/JSPlatform.scala
@@ -1,10 +1,11 @@
-package scalajscrossproject
+/* It is totally evil to introduce a class in the package of sbt-scalajs, but that is
+ * the only way we can be forward source compatible with Scala.js 1.x.
+ */
+package org.scalajs.sbtplugin
 
 import sbtcrossproject._
 
 import sbt._
-
-import org.scalajs.sbtplugin.{ScalaJSCrossVersion, ScalaJSPlugin}
 
 case object JSPlatform extends Platform {
   def identifier: String                = "js"

--- a/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/ScalaJSCross.scala
+++ b/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/ScalaJSCross.scala
@@ -9,7 +9,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin
 import scala.language.implicitConversions
 
 trait ScalaJSCross {
-  val JSPlatform = scalajscrossproject.JSPlatform
+  val JSPlatform = org.scalajs.sbtplugin.JSPlatform
 
   implicit def JSCrossProjectBuilderOps(
       builder: CrossProject.Builder): JSCrossProjectOps =

--- a/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/ScalaJSCrossPlugin.scala
+++ b/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/ScalaJSCrossPlugin.scala
@@ -22,6 +22,8 @@ object ScalaJSCrossPlugin extends AutoPlugin {
       new ScalaJSGroupIDCompat(groupID)
   }
 
+  import autoImport._
+
   override def projectSettings: Seq[Setting[_]] = Seq(
     crossPlatform := JSPlatform
   )


### PR DESCRIPTION
With these changes, the following branch of Scala.js works: https://github.com/scala-js/scala-js/compare/master...sjrd:sbt-crossproject