### PR TITLE
Fix the dependency on sbt-scalajs when cross-building for sbt 1.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_script:
 script:
   - java -version
   - bin/scalafmt --test && sbt sbt-crossproject-test/scripted
-  - sbt "++ 2.12.3" "^^ 1.0.0" sbt-crossproject/publishLocal
+  - sbt "++ 2.12.3" "^^ 1.0.0" sbt-crossproject/publishLocal sbt-scalajs-crossproject/publishLocal
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,19 @@ lazy val `sbt-scalajs-crossproject` =
     .settings(sbtPluginSettings)
     .settings(
       moduleName := "sbt-scalajs-crossproject",
-      addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+      /* Work around https://github.com/sbt/sbt/issues/3393.
+       * Should be:
+       *   addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+       * We inline the fixed definition of addSbtPlugin to be
+       * released with sbt 0.13.17.
+       */
+      libraryDependencies += {
+        val sbtV   = (sbtBinaryVersion in pluginCrossBuild).value
+        val scalaV = (scalaBinaryVersion in update).value
+        Defaults.sbtPluginExtra("org.scala-js" % "sbt-scalajs" % "0.6.19",
+                                sbtV,
+                                scalaV)
+      }
     )
     .settings(publishSettings)
     .enablePlugins(BintrayPlugin)


### PR DESCRIPTION
Due to https://github.com/sbt/sbt/issues/3393, we cannot use `addSbtPlugin` because it is broken in 0.13.16 for cross-building scenarios. Instead, we inline the fixed definition that will be released in 0.13.17.